### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/components/CopyToClipboard.test.tsx
+++ b/components/CopyToClipboard.test.tsx
@@ -28,7 +28,7 @@ test('render and properly copy to clipboard', async () => {
   // trying to use jest.useFakeTimers timeout test
   // similiar issue to https://github.com/facebook/jest/issues/11607
   await screen.findByLabelText('copy to clipboard', undefined, {
-    timeout: 3000,
+    timeout: 1985,
   });
   icon = screen.getByLabelText('copy to clipboard');
   await userEvent.unhover(icon);


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 3000ms to 1985ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.